### PR TITLE
install_IMGT_germline_db fails due to missing path

### DIFF
--- a/R/create_IMGT_germline_db.R
+++ b/R/create_IMGT_germline_db.R
@@ -205,6 +205,8 @@ create_IMGT_germline_db <- function(organism_path, destdir,
     dir.create(tmpdestdir, recursive=TRUE)
     on.exit(unlink(tmpdestdir, recursive=TRUE, force=TRUE))
     FUN(organism_path, tmpdestdir, edit_fasta_script)
+    if (!dir.exists(dirname(destdir)))
+       dir.create(dirname(destdir))
     replace_file(destdir, tmpdestdir)
 }
 


### PR DESCRIPTION
Hello, following the README, I was getting an error regarding a missing path when installing the germline database. I have made a small edit to the `create_IMGT_germline_db` function that checks for the db directory, then creates the directory if it's missing. 