### PR TITLE
add instuctions for installing Bioconductor dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ feedback, request features, etc...
 
 ### 1. Install and load igblastr
 
+#### Install Bioconductor dependencies
+
+    if (!require("BiocManager", quietly = TRUE))
+        install.packages("BiocManager")
+
+    BiocManager::install(c('Biostrings','S4Vectors','GenomeInfoDb'))
+
 #### Install igblastr
 
     if (!require(remotes, quietly=TRUE))


### PR DESCRIPTION
Hello, I am not sure what your intentions are for how users install the Bioconductor package dependencies, so please feel free to ignore if this suggestion isn't ideal. I was getting the following error when installing this package using the instructions provided in the README:

```
ERROR: dependencies ‘Biostrings’, ‘S4Vectors’, ‘GenomeInfoDb’ are not available for package ‘igblastr’
```

I think the additional instructions I have provided in this PR are required. Thanks!